### PR TITLE
Remove deprecated `load/unload` event shorthands

### DIFF
--- a/src/event.js
+++ b/src/event.js
@@ -252,7 +252,7 @@
   }
 
   // shortcut methods for `.bind(event, fn)` for each event type
-  ;('focusin focusout focus blur load resize scroll unload click dblclick '+
+  ;('focusin focusout focus blur resize scroll click dblclick '+
   'mousedown mouseup mousemove mouseover mouseout mouseenter mouseleave '+
   'change select keydown keypress keyup error').split(' ').forEach(function(event) {
     $.fn[event] = function(callback) {

--- a/test/event.html
+++ b/test/event.html
@@ -464,6 +464,12 @@
         span.trigger(event)
         t.assertTrue(event.isDefaultPrevented())
         t.assertTrue(event.isPropagationStopped())
+      },
+
+      testThereIsNoLoadShortcut: function(t){
+        var z = $()
+        t.assertUndefined(z.load)
+        t.assertUndefined(z.unload)
       }
 
     })

--- a/test/zepto.html
+++ b/test/zepto.html
@@ -3228,7 +3228,7 @@
       },
 
       testDOMEventWrappers: function(t){
-        var events = ('blur focus focusin focusout load resize scroll unload click dblclick '+
+        var events = ('blur focus focusin focusout resize scroll click dblclick '+
           'mousedown mouseup mousemove mouseover mouseout '+
           'change select keydown keypress keyup error').split(' ')
 


### PR DESCRIPTION
They were deprecated in jQuery 1.8 and conflict with Ajax `fn.load()`
method. Depending on the order of Zepto modules, `load()` was an
entirely different method, so to resolve the conflict we remove the
deprecated shorthands for event handling.

Fixes loading "event" module after "ajax" and not having Ajax `load()`
method overriden.ZEPTO